### PR TITLE
add ability to customzie the URL where go install files are downloaded from

### DIFF
--- a/libexec/gobrew-install
+++ b/libexec/gobrew-install
@@ -29,24 +29,28 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-download="https://go.googlecode.com/files/go${version}.${platform}-${arch}.tar.gz"
+# Allow the GO_FILES_URL environment variable override the location of the
+# go installation files
+files_url=${GO_FILES_URL:=https://go.googlecode.com/files/}
+file_name="go${version}.${platform}-${arch}.tar.gz"
+download=$files_url$file_name
 
 set +e
 
 (
     if type wget &>/dev/null; then
-        echo "Installing go${version}.${platform}-${arch}.tar.gz"
+        echo "Installing $file_name"
         wget -P "$GOBREW_ROOT/cache" "${download}"
-        tar -zxf "$GOBREW_ROOT/cache/go${version}.${platform}-${arch}.tar.gz" --strip-components 1
+        tar -zxf "$GOBREW_ROOT/cache/$file_name" --strip-components 1
     elif type curl &>/dev/null; then
-        echo "Installing go${version}.${platform}.${arch}.tar.gz"
-        curl -s -f "$download" > "$GOBREW_ROOT/cache/go${version}.${platform}-${arch}.tar.gz"
-        tar -zxf "$GOBREW_ROOT/cache/go${version}.${platform}-${arch}.tar.gz" --strip-components 1
+        echo "Installing $file_name"
+        curl -s -f "$download" > "$GOBREW_ROOT/cache/$file_name"
+        tar -zxf "$GOBREW_ROOT/cache/$file_name" --strip-components 1
     else
         echo "error: please install \`curl\` or \`wget\` and try again" >&2
         exit 1
     fi
-    rm "$GOBREW_ROOT/cache/go${version}.${platform}-${arch}.tar.gz"
+    rm "$GOBREW_ROOT/cache/$file_name"
 ) || \
     {
         cd $OLDPWD


### PR DESCRIPTION
Updated gobrew-install so the URL where go installation are pulled from can be overridden via an environment variabnle named GO_FILES_URL.

The motivation here is to allow gobrew::fw to customize the URL for gobrew users who are behind a firewall.
