### PR TITLE
fixed gobrew list command to list all available versions

### DIFF
--- a/libexec/gobrew-list
+++ b/libexec/gobrew-list
@@ -18,7 +18,10 @@ fi
 
 echo "finding Go versions for $platform-$arch"
 
-go_downloads_list="https://code.google.com/p/go/downloads/list"
+# Allow the GO_DOWNLOADS_URL_LIST environment variable override the location of the
+# go installation files
+url=${GO_DOWNLOADS_LIST_URL:=https://code.google.com/p/go/downloads/list?can=1&num=10000}
+go_downloads_list=$url
 curl -s $go_downloads_list \
 | grep "<a href=\"//go.googlecode.com/files/go.*\.tar\.gz" \
 | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' \


### PR DESCRIPTION
the url being used only showed the versions from the "current" downloads page instead of all available versions.
