### PR TITLE
update install.sh to source profile after install

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,5 +34,7 @@ esac
 echo "${export_command}" >> "$HOME/.$profile"
 echo "${eval_command}" >> "$HOME/.$profile"
 
+source "$HOME/.$profile"
+
 echo "\n\n\033[0;32mGobrew is now installed.\033[0m"
 echo "Run 'gobrew' command for information."


### PR DESCRIPTION
sourcing the profile causes the gobrew-init script to run which sets up directories and other stuff which is required to install go. (ex: $HOME/.gobrew/cache gets created)
