### PR TITLE
update list command to be less restrictive when greping for files

### DIFF
--- a/libexec/gobrew-list
+++ b/libexec/gobrew-list
@@ -23,7 +23,7 @@ echo "finding Go versions for $platform-$arch"
 url=${GO_DOWNLOADS_LIST_URL:=https://code.google.com/p/go/downloads/list?can=1&num=10000}
 go_downloads_list=$url
 curl -s $go_downloads_list \
-| grep "<a href=\"//go.googlecode.com/files/go.*\.tar\.gz" \
+| grep "<a href=\"//.*/files/go.*\.tar\.gz" \
 | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' \
 | sed -n 's/.*files\/\(go.*\.tar\.gz\)/\1/p' \
 | sed -n "s/go\(.*\)\.$platform-$arch.*/\1/p" \


### PR DESCRIPTION
by not including "go.googlecode.com" in the grep regex, it'll make it easier for gobrew_fw to host the files while to still enabling `gobrew list` to work.
