### PR TITLE
Local version file should be file,not directory.

### DIFF
--- a/libexec/gobrew-version-file
+++ b/libexec/gobrew-version-file
@@ -12,7 +12,7 @@ set -e
 find_local_version_file() {
   local root="$1"
   while [ -n "$root" ]; do
-    if [ -e "${root}/version" ]; then
+    if [ ! -d "${root}/version" ] && [ -e "${root}/version" ]; then
       echo "${root}/version"
       exit
     fi


### PR DESCRIPTION

```
If some directory has  "version" directory, go command in `gobrew` does not works.

$ls
CONTRIBUTING.md  LICENSE     api        flags.go  join_test.go  manage.go  state
Dockerfile       README.md   cluster    help.go   logo.png      scheduler  userguide.md
Godeps           ROADMAP.md  discovery  join.go   main.go       script     version
$go
cat: /home/anarch/go/swarm/src/github.com/docker/swarm/version: Is a directory
gobrew: couldn't find any version specified for use
```

