### PR TITLE
Fix gobrew list debug flag

### DIFF
--- a/libexec/gobrew-list
+++ b/libexec/gobrew-list
@@ -4,7 +4,7 @@
 
 set -e
 
-[ -n "$GOBREW_DEBUG"] && {
+[ -n "$GOBREW_DEBUG" ] && {
     set -x
 }
 


### PR DESCRIPTION
Fixed spacing in `gobrew-list`

Before fix output: 
```
➜  gobrew git:(feature/fix-gobrew-list-output) gobrew list
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ platform=darwin
++ uname -m
+ '[' x86_64 = x86_64 ']'
+ arch=amd64
+ echo 'finding Go versions for darwin-amd64'
finding Go versions for darwin-amd64
+ url=http://golang.org/dl/
+ go_downloads_list=http://golang.org/dl/
+ curl -s http://golang.org/dl/
+ grep -o '<a href=".*//.*/golang/go.*\.tar\.gz'
+ sed -e 's/<a .*href=['\''"]//' -e 's/["'\''].*$//' -e '/^$/ d'
+ sed -n 's/.*golang\/\(go.*\.tar\.gz\)/\1/p'
+ sed -n 's/go\(.*\)\.darwin-amd64.*/\1/p'
+ uniq
+ sort
1.2.2
1.3
1.3.1
1.3.2
1.3.3
1.3rc1
1.3rc2
1.4
1.4.1
1.4.2
1.4beta1
1.4rc1
1.4rc2
```

After:
```
➜  gobrew git:(feature/fix-gobrew-list-output) ./libexec/gobrew-list
finding Go versions for darwin-amd64
1.2.2
1.3
1.3.1
1.3.2
1.3.3
1.3rc1
1.3rc2
1.4
1.4.1
1.4.2
1.4beta1
1.4rc1
1.4rc2
```

With flag:
```
➜  gobrew git:(feature/fix-gobrew-list-output) GOBREW_DEBUG=true ./libexec/gobrew-list
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ platform=darwin
++ uname -m
+ '[' x86_64 = x86_64 ']'
+ arch=amd64
+ echo 'finding Go versions for darwin-amd64'
finding Go versions for darwin-amd64
+ url=http://golang.org/dl/
+ go_downloads_list=http://golang.org/dl/
+ curl -s http://golang.org/dl/
+ grep -o '<a href=".*//.*/golang/go.*\.tar\.gz'
+ sed -e 's/<a .*href=['\''"]//' -e 's/["'\''].*$//' -e '/^$/ d'
+ sed -n 's/.*golang\/\(go.*\.tar\.gz\)/\1/p'
+ sed -n 's/go\(.*\)\.darwin-amd64.*/\1/p'
+ uniq
+ sort
1.2.2
1.3
1.3.1
1.3.2
1.3.3
1.3rc1
1.3rc2
1.4
1.4.1
1.4.2
1.4beta1
1.4rc1
1.4rc2
```