### PR TITLE
Change go 1.5 download path & local gobrew version file name  (version -> gobrew_version )

### DIFF
--- a/libexec/gobrew-install
+++ b/libexec/gobrew-install
@@ -40,13 +40,16 @@ version_major="$(echo $version | cut -d . -f 1)"
 version_minor="$(echo $version | cut -d . -f 2)"
 
 if [ $platform = "darwin" -a $version_minor -gt 1 ]; then
-
-    darwin_major="$(uname -r | cut -d . -f 1)"
-
-    if [ $darwin_major -lt 11 ]; then
-        file_name="go${version}.${platform}-${arch}-osx10.6.tar.gz"
+    if [ $version_minor -gt 4 ]; then
+        file_name="go${version}.${platform}-${arch}.tar.gz"
     else
-        file_name="go${version}.${platform}-${arch}-osx10.8.tar.gz"
+        darwin_major="$(uname -r | cut -d . -f 1)"
+
+        if [ $darwin_major -lt 11 ]; then
+            file_name="go${version}.${platform}-${arch}-osx10.6.tar.gz"
+        else
+            file_name="go${version}.${platform}-${arch}-osx10.8.tar.gz"
+        fi
     fi
 else
     file_name="go${version}.${platform}-${arch}.tar.gz"

--- a/libexec/gobrew-version-file
+++ b/libexec/gobrew-version-file
@@ -12,8 +12,8 @@ set -e
 find_local_version_file() {
   local root="$1"
   while [ -n "$root" ]; do
-    if [ ! -d "${root}/version" ] && [ -e "${root}/version" ]; then
-      echo "${root}/version"
+    if [ ! -d "${root}/gobrew_version" ] && [ -e "${root}/gobrew_version" ]; then
+      echo "${root}/gobrew_version"
       exit
     fi
     root="${root%/*}"


### PR DESCRIPTION
### go1.5 download path 

#23 

###  local gobrew version file name (version -> gobrew_version)
Sometimes, if I used the `version` file name in my project, it caused some confusion about gobrew. 
`Version` is too normal of a file name, so I changed the file name to `gobrew_version`.
 

