### PR TITLE
Fix list command

### DIFF
--- a/libexec/gobrew-list
+++ b/libexec/gobrew-list
@@ -19,7 +19,7 @@ echo "finding Go versions for $platform-$arch"
 url=${GO_DOWNLOADS_LIST_URL:=http://golang.org/dl/}
 go_downloads_list=$url
 curl -s $go_downloads_list \
-| grep -o "<a href=\".*//.*/golang/go.*\.tar\.gz" \
+| grep -o "<a.*href=\".*//.*/golang/go.*\.tar\.gz" \
 | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' \
 | sed -n 's/.*golang\/\(go.*\.tar\.gz\)/\1/p' \
 | sed -n "s/go\(.*\)\.$platform-$arch.*/\1/p" \


### PR DESCRIPTION
go's download page has anchors which didn't match the regex anymore