### PR TITLE
fix a requested location page to work gobrew-list

### DIFF
--- a/libexec/gobrew-list
+++ b/libexec/gobrew-list
@@ -18,7 +18,7 @@ echo "finding Go versions for $platform-$arch"
 # go installation files
 url=${GO_DOWNLOADS_LIST_URL:=http://golang.org/dl/}
 go_downloads_list=$url
-curl -s $go_downloads_list \
+curl -sL $go_downloads_list \
 | grep -o "<a.*href=\".*//.*/golang/go.*\.tar\.gz" \
 | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' \
 | sed -n 's/.*golang\/\(go.*\.tar\.gz\)/\1/p' \


### PR DESCRIPTION
it seems to need a location handler in curl command for working gobrew-list.
--
% curl -s http://golang.org/dl/
<a href="https://golang.org/dl/">Found</a>.
--